### PR TITLE
Fix: Update metadata.ini with empty email keys

### DIFF
--- a/metadata.ini
+++ b/metadata.ini
@@ -4,6 +4,7 @@ collections=qpws,qld_veg_management
 [qpws]
 name=QPWS
 author=Shaun Kolomeitz
+email=
 tags=qld, environment, protected areas, national parks, wildlife
 description=These files emulate the internal representation of the Queensland Parks and Wildlife Service, Protected Area Estate.
 qgis_minimum_version=2.0
@@ -13,6 +14,7 @@ preview=preview/QPWS_estate_FILL.png
 [qld_veg_management]
 name=QLD-Vegetation-Management
 author=QLD Globe
+email=
 tags=qld, environment, protected areas, vegetation, wetlands, waterways, regional ecosystem
 description=These files were taken from the QLD Government online vegetation management data files
 qgis_minimum_version=2.0


### PR DESCRIPTION
Hello!
I'm yet to introduce myself (Rick) but I encountered an error when trying to add the QGISau repo into QGIS Resource Sharing

`Unable to add repository: Error parsing metadata for Australian QGIS Styles: Error parsing metadata: No option 'email' in section: 'qpws'`

By comparing to a couple of the default repositories, I saw that an empty `email=` appeared acceptable, then verified it myself. 